### PR TITLE
Fix for readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+python:
+  install:
+    - requirements: requirements/docs.txt
+    - method: pip
+      path: .
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   builder: html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -27,3 +27,5 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  apt_packages:
+    - graphviz


### PR DESCRIPTION
Looks like this worked:

https://dplutils--8.org.readthedocs.build/en/8/index.html (built from https://readthedocs.org/projects/dplutils/builds/)


