### PR TITLE
Add framework for graph streaming, ray implementation

### DIFF
--- a/dplutils/pipeline/__init__.py
+++ b/dplutils/pipeline/__init__.py
@@ -1,4 +1,5 @@
 from .task import PipelineTask
 from .executor import PipelineExecutor
+from .graph import PipelineGraph
 
-__all__ = ['PipelineTask', 'PipelineExecutor']
+__all__ = ['PipelineTask', 'PipelineExecutor', 'PipelineGraph']

--- a/dplutils/pipeline/executor.py
+++ b/dplutils/pipeline/executor.py
@@ -25,13 +25,16 @@ class PipelineExecutor(ABC):
             self.graph = PipelineGraph(deepcopy(graph))
         else:
             self.graph = deepcopy(graph)
-        self.tasks_idx = self.graph.task_map  # for back compat
         self.ctx = {}
         self._run_id = None
 
     @classmethod
     def from_graph(cls, graph: PipelineGraph) -> 'PipelineExecutor':
         return cls(graph)
+
+    @property
+    def tasks_idx(self):  # for back compat
+        return self.graph.task_map
 
     def set_context(self, key, value) -> 'PipelineExecutor':
         self.ctx[key] = value

--- a/dplutils/pipeline/graph.py
+++ b/dplutils/pipeline/graph.py
@@ -1,0 +1,65 @@
+from enum import Enum
+from networkx import DiGraph, path_graph, all_simple_paths, is_directed_acyclic_graph, bfs_edges
+from dplutils.pipeline.task import PipelineTask
+
+
+class TRM(Enum):
+    sink = 'sink'
+    source = 'source'
+
+
+class PipelineGraph(DiGraph):
+    def __init__(self, graph=None):
+        if isinstance(graph, list) and isinstance(graph[0], PipelineTask):
+            graph = path_graph(graph, DiGraph)
+        super().__init__(graph)
+        if not is_directed_acyclic_graph(self):
+            raise ValueError('cycles detected in graph')
+
+    @property
+    def task_map(self):
+        return {i.name: i for i in self}
+
+    @property
+    def source_tasks(self):
+        return [n for n,d in self.in_degree() if d == 0]
+
+    @property
+    def sink_tasks(self):
+        return [n for n,d in self.out_degree() if d == 0]
+
+    def to_list(self):
+        if len(self.source_tasks) != 1 or len(self.sink_tasks) != 1:
+            raise ValueError('to_list requires a graph with only one start and end task')
+        source = self.source_tasks[0]
+        sink = self.sink_tasks[0]
+        if source == sink:
+            return [source]
+        paths = list(all_simple_paths(self, source, sink))
+        if len(paths) != 1:
+            raise ValueError('to_list requires a single path from start to end task, found {len(paths)}')
+        return paths[0]
+
+    def with_terminals(self):
+        graph = self.copy()
+        graph.add_edges_from((TRM.source, i) for i in self.source_tasks)
+        graph.add_edges_from((i, TRM.sink) for i in self.sink_tasks)
+        return graph
+
+    def _walk(self, source, back=False, sort_key=None):
+        graph = self.with_terminals()
+        # doubly wrap the sort key function for conveneince (since bfs search
+        # takes list, not sort key) and to inject the ignoring of terminal
+        # nodes. This makes the walk sort key behave a bit more like `sorted()`
+        def _sort_key(x):
+            return 0 if isinstance(x, TRM) else sort_key(x)
+        sorter = (lambda x: sorted(x, key=_sort_key)) if sort_key else None
+        for _, node in bfs_edges(graph, source, reverse=back, sort_neighbors=sorter):
+            if not isinstance(node, TRM):
+                yield node
+
+    def walk_fwd(self, source=None, sort_key=None):
+        return self._walk(source or TRM.source, sort_key=sort_key)
+
+    def walk_back(self, source=None, sort_key=None):
+        return self._walk(source or TRM.sink, back=True, sort_key=sort_key)

--- a/dplutils/pipeline/graph.py
+++ b/dplutils/pipeline/graph.py
@@ -59,7 +59,7 @@ class PipelineGraph(DiGraph):
                 yield node
 
     def walk_fwd(self, source=None, sort_key=None):
-        return self._walk(source or TRM.source, sort_key=sort_key)
+        return self._walk(source or TRM.source, back=False, sort_key=sort_key)
 
     def walk_back(self, source=None, sort_key=None):
         return self._walk(source or TRM.sink, back=True, sort_key=sort_key)

--- a/dplutils/pipeline/ray.py
+++ b/dplutils/pipeline/ray.py
@@ -1,8 +1,13 @@
 import ray
 import pandas as pd
 import numpy as np
+from collections import defaultdict
+from copy import copy
+from dataclasses import dataclass
+from itertools import chain
 from dplutils import observer
 from dplutils.pipeline import PipelineTask, PipelineExecutor
+from dplutils.pipeline.stream import StreamingGraphExecutor, StreamBatch
 
 
 def set_run_id(inputs, run_id):
@@ -64,6 +69,7 @@ class RayDataPipelineExecutor(PipelineExecutor):
     """
     def __init__(self, graph, n_batches: int = 100, **kwargs):
         super().__init__(graph, **kwargs)
+        self.tasks = self.graph.to_list()
         self.n_batches = n_batches
 
     def make_pipeline(self):
@@ -96,3 +102,111 @@ class RayDataPipelineExecutor(PipelineExecutor):
         pipeline = self.make_pipeline()
         for batch in pipeline.iter_batches(batch_size = None, batch_format = 'pandas', prefetch_batches = 0):
             yield batch
+
+
+def get_stream_wrapper(task: PipelineTask, context: dict):
+    obs = observer.get_observer()
+    def wrapper(*df_list):
+        observer.set_observer(obs)
+        task_df = pd.concat(df_list)
+        kwargs = task.resolve_kwargs(context)
+        df = task.func(task_df, **kwargs)
+        return len(df), df
+    return wrapper
+
+
+def stream_split_func(df, splits):
+    splits = np.array_split(df, splits)
+    return [len(i) for i in splits] + splits
+
+
+def task_resources(task):
+    r = copy(task.resources)
+    r['num_cpus'] = task.num_cpus
+    r['num_gpus'] = task.num_gpus
+    return {k: v or 0 for k,v in r.items()}
+
+
+@dataclass
+class RemoteTracker:
+    task: PipelineTask
+    refs: list[ray.ObjectRef]
+    is_split: bool = False
+
+
+class RayStreamGraphExecutor(StreamingGraphExecutor):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # bootstrap remote tasks at initialization and keep reference - this is
+        # more efficient than doing so for each remote task run due to required
+        # serialization
+        self.remote_task_map = {}
+        for name, task in self.graph.task_map.items():
+            self.remote_task_map[name] = ray.remote(
+                get_stream_wrapper(task, self.ctx)
+            ).options(
+                num_cpus = task.num_cpus,
+                num_gpus = task.num_gpus,
+                resources = task.resources,
+                name = f'{task.name}<{task.func.__name__}>',
+                num_returns = 2,  # the remote wrapper returns (len of df, df)
+            )
+        self.remote_splitter = ray.remote(stream_split_func)
+        self.sched_resources = defaultdict(float)
+
+    def execute(self):
+        if not ray.is_initialized():
+            ray.init()
+        for batch in super().execute():
+            yield ray.get(batch)
+
+    def task_submittable(self, task, rank):
+        cluster_r = ray.cluster_resources()
+        task_r = task_resources(task)
+        for k in task_r:
+            ck_map = {'num_cpus': 'CPU', 'num_gpus': 'GPU'}
+            avail = cluster_r.get(ck_map.get(k, k), 0) - self.sched_resources.get(k, 0)
+            # Overcommit the resources for all downstream tasks to ensure that
+            # upstream tasks cant starve those that don't presently fit. Source
+            # only overcommits if there is nothing downstream since the system
+            # can be considered starved
+            if task in self.graph.source_tasks and rank > 0 and task_r[k] > avail:
+                return False
+            elif avail < 0:
+                return False
+        return True
+
+    def task_submit(self, task, df_list):
+        remote_task = self.remote_task_map[task.name]
+        for r,v in task_resources(task).items():
+            self.sched_resources[r] += v
+        refs = remote_task.remote(*df_list)
+        return RemoteTracker(task, refs)
+
+    def task_ready(self, remote_task):
+        ready, _ = ray.wait(remote_task.refs, timeout=0, fetch_local=False)
+        if len(ready) == 0:
+            return False
+        if not remote_task.is_split:
+            for r,v in task_resources(remote_task.task).items():
+                self.sched_resources[r] -= v
+        return True
+
+    def split_batch_submit(self, stream_batch, max_rows):
+        splits = int(np.ceil(stream_batch.length/max_rows))
+        refs = self.remote_splitter.options(num_returns=splits*2).remote(stream_batch.data, splits)
+        return RemoteTracker(None, refs, True)
+
+    def task_resolve_output(self, remote_task):
+        if remote_task.is_split:
+            num = int(len(remote_task.refs) / 2)
+            return [StreamBatch(ray.get(remote_task.refs[i]), remote_task.refs[i+num]) for i in range(num)]
+        return StreamBatch(ray.get(remote_task.refs[0]), remote_task.refs[1])
+
+    def poll_tasks(self, remote_task_list):
+        all_refs = list(chain.from_iterable(i.refs for i in remote_task_list))
+        # The timeout here is to ensure we can process through the tasks again
+        # in the case where the cluster is expanded. The timescale here just
+        # needs to be on the order of how long it takes to get new hardware
+        # added to cluster (expected seconds/minutes timescale)
+        ray.wait(all_refs, timeout=20, fetch_local=False)

--- a/dplutils/pipeline/stream.py
+++ b/dplutils/pipeline/stream.py
@@ -1,0 +1,214 @@
+import numpy as np
+import pandas as pd
+import networkx as nx
+from abc import ABC, abstractmethod
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any
+from dplutils.pipeline import PipelineTask, PipelineExecutor
+from dplutils.pipeline.utils import deque_extract
+
+
+@dataclass
+class StreamBatch:
+    length: int
+    data: Any
+
+
+@dataclass
+class StreamTask:
+    task: PipelineTask
+    data_in: list[StreamBatch] = field(default_factory=deque)
+    pending: list = field(default_factory=deque)
+    counter: int = 0
+    split_pending: list = field(default_factory=deque)
+
+    def __hash__(self):
+        return hash(self.task)
+
+    @property
+    def name(self):
+        return self.task.name
+
+    def total_pending(self):
+        return sum(len(i)  for i in [self.data_in, self.pending, self.split_pending])
+
+
+class StreamingGraphExecutor(PipelineExecutor, ABC):
+    def __init__(self, graph, max_batches=None):
+        super().__init__(graph)
+        self.max_batches = max_batches
+        # make a local copy of the graph with each node wrapped in a tracker
+        # object
+        self.stream_graph = nx.relabel_nodes(self.graph, StreamTask)
+
+    def execute(self):
+        self.n_sourced = 0
+        self.source_exhausted = False
+        self.source_generator = self.source_generator_fun()
+        while True:
+            batch = self.execute_until_output()
+            if batch is None:
+                return
+            yield batch
+
+    def source_generator_fun(self):
+        bid = 0
+        while True:
+            yield pd.DataFrame({'run_id': [self.run_id], 'id': [bid]})
+            bid += 1
+
+    def get_pending(self):
+        return [p for tn in self.stream_graph for p in tn.pending]
+
+    def task_exhausted(self, task=None):
+        n = 0 if task is None else len(task.split_pending)
+        for upstream in self.stream_graph.walk_back(task):
+            n += upstream.total_pending()
+        return n == 0
+
+    def resolve_completed(self):
+        # Walk graph forward to promote completed tasks to next task
+        # queue. Dataframes for completed sink tasks are returned here in order
+        # to prioritize flushing.
+        for task in self.stream_graph.walk_fwd():
+            for ready in deque_extract(task.pending, self.task_ready):
+                block_info = self.task_resolve_output(ready)
+                if task in self.stream_graph.sink_tasks:
+                    return block_info.data
+                else:
+                    for next_task in self.stream_graph.neighbors(task):
+                        next_task.data_in.appendleft(block_info)
+
+            for ready in deque_extract(task.split_pending, self.task_ready):
+                task.data_in.extend(self.task_resolve_output(ready))
+        return None
+
+    def process_source(self, source):
+        source_batch = []
+        for _ in range(source.task.batch_size or 1):
+            source_batch.append(next(self.source_generator))
+            self.n_sourced += 1
+            if self.n_sourced == self.max_batches:
+                self.source_exhausted = True
+                break
+        source.pending.append(self.task_submit(source.task, source_batch))
+        source.counter += 1
+
+    def enqueue_tasks(self):
+        # Work through the graph in reverse order, submitting any tasks as
+        # needed. Reverse order ensures we prefer to send tasks that are closer
+        # to the end of the pipeline and only feed as necessary.
+        rank = 0
+        for task in self.stream_graph.walk_back(sort_key=lambda x: x.counter):
+            if task in self.stream_graph.source_tasks:
+                continue
+            elif len(task.data_in) == 0:
+                continue
+
+            batch_size = task.task.batch_size
+            if batch_size is not None:
+                for batch in deque_extract(task.data_in, lambda b: b.length > batch_size):
+                    task.split_pending.append(self.split_batch_submit(batch, batch_size))
+
+            while len(task.data_in) > 0:
+                num_to_merge = deque_num_merge(task.data_in, batch_size)
+                if num_to_merge == 0:
+                    # If the feed is terminated and there are no more tasks that
+                    # will feed to this one, submit everything
+                    if self.source_exhausted and self.task_exhausted(task):
+                        num_to_merge = len(task.data_in)
+                    else:
+                        break
+                rank += 1  # independent of whether it can be subitted -- update if ready
+                if not self.task_submittable(task.task, rank):
+                    break
+                merged = [task.data_in.pop().data for i in range(num_to_merge)]
+                task.pending.append(self.task_submit(task.task, merged))
+                task.counter += 1
+
+        # in least-run order try to enqueue as many of the source tasks as can fit
+        while True:
+            task_scheduled = False
+            for source in sorted(self.stream_graph.source_tasks, key=lambda x: x.counter):
+                if self.source_exhausted or not self.task_submittable(source.task, rank):
+                    continue
+                self.process_source(source)
+                task_scheduled = True
+            if not task_scheduled:
+                break
+
+    def execute_until_output(self):
+        while True:
+            if (completed := self.resolve_completed()) is not None:
+                return completed
+
+            if self.source_exhausted and self.task_exhausted():
+                return None
+
+            self.enqueue_tasks()
+            self.poll_tasks(self.get_pending())
+
+    @abstractmethod
+    def task_submit(self, task: PipelineTask, df_list: list[pd.DataFrame]) -> Any:
+        pass
+
+    @abstractmethod
+    def task_resolve_output(self, pending_task: Any) -> StreamBatch:
+        pass
+
+    @abstractmethod
+    def task_ready(self, pending_task: Any) -> bool:
+        pass
+
+    @abstractmethod
+    def task_submittable(self, task: PipelineTask, rank: int) -> bool:
+        pass
+
+    @abstractmethod
+    def split_batch_submit(self, batch: StreamBatch, max_rows: int) -> Any:
+        pass
+
+    @abstractmethod
+    def poll_tasks(self, pending_task_list: list[Any]) -> None:
+        pass
+
+
+class LocalSerialExecutor(StreamingGraphExecutor):
+    # for testing purposes
+    sflag = 0
+
+    def task_submit(self, pt, df_list):
+        self.sflag = 1
+        return pt.func(pd.concat(df_list))
+
+    def split_batch_submit(self, stream_batch, max_rows):
+        df = stream_batch.data
+        return np.array_split(df, np.ceil(len(df) / max_rows))
+
+    def task_resolve_output(self, to):
+        if isinstance(to, list):
+            return [StreamBatch(len(i), i) for i in to]
+        return StreamBatch(len(to), to)
+
+    def task_submittable(self, t, rank):
+        return self.sflag == 0
+
+    def task_ready(self, t):
+        return True
+
+    def poll_tasks(self, pending):
+        self.sflag = 0
+
+
+def deque_num_merge(queue, batch_size):
+    if batch_size is None:
+        return 1 if len(queue) > 0 else 0
+    else:
+        # So long as batch size is set, try to merge if necessary. Proceed in
+        # fifo order and take up to batch_size rows, but no more.
+        s_accum = np.cumsum([i.length for i in reversed(queue)])
+        idxs, = np.where(s_accum >= batch_size)
+        if len(idxs) == 0:
+            return 0
+        return idxs[0] + 1

--- a/dplutils/pipeline/task.py
+++ b/dplutils/pipeline/task.py
@@ -86,3 +86,6 @@ class PipelineTask:
         extra = set(all_kwargs.keys()) - {k for k,v in params}
         if len(extra) > 0:
             raise ValueError(f'unkown arguments {extra} for task {self.name}')
+
+    def __hash__(self):
+        return hash(self.name)

--- a/dplutils/pipeline/utils.py
+++ b/dplutils/pipeline/utils.py
@@ -9,6 +9,8 @@ def dict_from_coord(coord, value):
 
 
 def deque_extract(queue, condition):
+    # pull items off the queue that match condition, while retaining the
+    # prioritization. Not thread-safe
     for i in range(len(queue)):
         if condition(queue[-1]):
             yield queue.pop()

--- a/dplutils/pipeline/utils.py
+++ b/dplutils/pipeline/utils.py
@@ -6,3 +6,11 @@ def dict_from_coord(coord, value):
     else:
         d[coord] = value
     return d
+
+
+def deque_extract(queue, condition):
+    for i in range(len(queue)):
+        if condition(queue[-1]):
+            yield queue.pop()
+        else:
+            queue.rotate()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "numpy",
     "ray[default]",
     "pyarrow",
+    "networkx",
 ]
 
 [project.optional-dependencies]

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,4 +1,4 @@
--r dev.txt
+-r prd.txt
 
 sphinx==7.2.6
 sphinx_rtd_theme==2.0.0

--- a/requirements/prd.txt
+++ b/requirements/prd.txt
@@ -1,5 +1,6 @@
-ray[default]==2.8.1
+ray[default]==2.9.0
 async-timeout==4.0.3
 pandas==2.1.4
 pyarrow==14.0.2
 numpy==1.26.2
+networkx==3.2.1

--- a/requirements/prd.txt
+++ b/requirements/prd.txt
@@ -1,4 +1,4 @@
-ray[default]==2.9.0
+ray[default]==2.9.1
 async-timeout==4.0.3
 pandas==2.1.4
 pyarrow==14.0.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pytest
 import ray
 from pathlib import Path
-from dplutils.pipeline import PipelineTask, PipelineExecutor
+from dplutils.pipeline import PipelineTask, PipelineExecutor, PipelineGraph
 
 
 DATA_PATH = Path(__file__).parent / "data"
@@ -43,6 +43,15 @@ def dummy_steps():
             func=lambda x: x.assign(step2 = len(x)),
         )
     ]
+
+
+@pytest.fixture
+def dummy_pipeline_graph():
+    t1 = PipelineTask('task1', lambda x: x.assign(t1 = '1'))
+    t2A = PipelineTask('task2A', lambda x: x.assign(t2A = '2A'))
+    t2B = PipelineTask('task2B', lambda x: x.assign(t2B = '2B'))
+    t3 = PipelineTask('task3', lambda x: x.assign(t3 = '3'))
+    return PipelineGraph([(t1, t2A), (t1, t2B), (t2A, t3), (t2B, t3)])
 
 
 @pytest.fixture

--- a/tests/observer/test_observer.py
+++ b/tests/observer/test_observer.py
@@ -15,6 +15,7 @@ def obsfunc():
         observer.param('param1', 'value1')
     return func
 
+
 @pytest.fixture
 def globalmemobs():
     obs = InMemoryObserver()

--- a/tests/pipeline/test_executor_base.py
+++ b/tests/pipeline/test_executor_base.py
@@ -62,11 +62,11 @@ def test_pipeline_executor_output_writer(dummy_executor, tmp_path):
     assert len(data.id) == 10
 
 
-def test_pipeline_executor_from_graph(dummy_executor, dummy_steps):
+def test_pipeline_executor_from_list_graph(dummy_executor, dummy_steps):
     executor_class = dummy_executor.__class__
     obj = executor_class.from_graph(dummy_steps)
     assert isinstance(obj, executor_class)
-    assert obj.tasks == dummy_steps
+    assert obj.graph.to_list() == dummy_steps
 
 
 def test_validate_records_and_raises_errors(dummy_executor):

--- a/tests/pipeline/test_pipeline_graph.py
+++ b/tests/pipeline/test_pipeline_graph.py
@@ -1,0 +1,104 @@
+import pytest
+from dataclasses import dataclass
+from dplutils.pipeline import PipelineTask, PipelineGraph
+
+
+def make_graph_struct(edges, sources, sinks, simple=None):
+    @dataclass
+    class GraphInfo:
+        edges: list[tuple]
+        sources: list[PipelineTask]
+        sinks: list[PipelineTask]
+        simple: list[PipelineTask]|None
+    return GraphInfo(edges, sources, sinks, simple)
+
+
+def graph_suite():
+    a = PipelineTask('a', 1)
+    b = PipelineTask('b', 2)
+    c = PipelineTask('c', 3)
+    d = PipelineTask('d', 4)
+    e = PipelineTask('e', 5)
+    f = PipelineTask('f', 6)
+    g = PipelineTask('g', 7)
+
+    return {
+        'simple': make_graph_struct([(a,b), (b,c), (c,d)], [a], [d], [a, b, c, d]),
+        'branched': make_graph_struct([(a,b), (b,c), (b,d), (c,e), (d,e)], [a], [e]),
+        'multisource': make_graph_struct([(a,c), (b,c), (c,d)], [a, b], [d]),
+        'multisink': make_graph_struct([(a,b), (b,c), (b,d)], [a], [c, d]),
+        'branchmulti': make_graph_struct([(a,c), (b,c), (c,d), (c,e), (d,f), (e,g)], [a,b], [f,g]),
+    }
+
+
+@pytest.mark.parametrize('graph_info', graph_suite().values())
+class TestGraph:
+    def test_graph_instantiation(self, graph_info):
+        PipelineGraph(graph_info.edges)
+
+    def test_graph_sinks_sources(self, graph_info):
+        p = PipelineGraph(graph_info.edges)
+        assert p.source_tasks == graph_info.sources
+        assert p.sink_tasks == graph_info.sinks
+
+    def test_graph_nodes_name_map(self, graph_info):
+        p = PipelineGraph(graph_info.edges)
+        assert isinstance(p.task_map, dict)
+        for i in p:
+            assert p.task_map[i.name] == i
+
+    def test_graph_with_terminals(self, graph_info):
+        p = PipelineGraph(graph_info.edges)
+        w_term = p.with_terminals()
+        for i in graph_info.sources:
+            assert len(p.in_edges(i)) == 0
+            assert len(w_term.in_edges(i)) == 1
+        for i in graph_info.sinks:
+            assert len(p.out_edges(i)) == 0
+            assert len(w_term.out_edges(i)) == 1
+
+    def test_graph_to_list(self, graph_info):
+        p = PipelineGraph(graph_info.edges)
+        if graph_info.simple is not None:
+            p.to_list() == graph_info.simple
+        else:
+            with pytest.raises(ValueError):
+                p.to_list()
+
+    def test_graph_walk_returns_node_list(self, graph_info):
+        p = PipelineGraph(graph_info.edges)
+        walked = list(p.walk_fwd())
+        assert walked[0] in graph_info.sources
+        assert walked[-1] in graph_info.sinks
+        assert len(walked) == len(p)
+        walked = list(p.walk_back())
+        assert walked[0] in graph_info.sinks
+        assert walked[-1] in graph_info.sources
+        assert len(walked) == len(p)
+
+
+def test_graph_walk_with_priority():
+    test = graph_suite()['branched']
+    p = PipelineGraph(test.edges)
+    walked = list(p.walk_back(sort_key=lambda x: x.func))
+    assert walked == [p.task_map[i] for i in ['e', 'c', 'd', 'b', 'a']]
+    walked = list(p.walk_fwd(sort_key=lambda x: x.func))
+    assert walked == [p.task_map[i] for i in ['a', 'b', 'c', 'd', 'e']]
+    # now reverse order
+    walked = list(p.walk_back(sort_key=lambda x: -x.func))
+    assert walked == [p.task_map[i] for i in ['e', 'd', 'c', 'b', 'a']]
+    walked = list(p.walk_fwd(sort_key=lambda x: -x.func))
+    assert walked == [p.task_map[i] for i in ['a', 'b', 'd', 'c', 'e']]
+
+
+def test_single_node_graph_to_list():
+    t = PipelineTask('t', 1)
+    p = PipelineGraph([t])
+    assert p.to_list() == [t]
+
+
+def test_graph_instantiation_raises_for_cycles():
+    a = PipelineTask('a', 1)
+    b = PipelineTask('b', 1)
+    with pytest.raises(ValueError):
+        PipelineGraph([(a, b), (b,a)])

--- a/tests/pipeline/test_ray_stream_executor.py
+++ b/tests/pipeline/test_ray_stream_executor.py
@@ -1,0 +1,52 @@
+import pytest
+import pandas as pd
+import dplutils.pipeline.ray
+from dplutils.pipeline import PipelineTask
+from dplutils.pipeline.ray import RayStreamGraphExecutor, get_stream_wrapper, stream_split_func
+from test_suite import PipelineExecutorTestSuite
+
+
+@pytest.fixture(autouse=True)
+def rayinit(raysession):
+    pass
+
+
+class TestRayStreamingGraphExecutor(PipelineExecutorTestSuite):
+    executor = RayStreamGraphExecutor
+
+
+def test_ray_stream_wrapper_func(pipelinestartdf):
+    def myfunc(df, ctx_in=None):
+        return df.assign(ctx_in = ctx_in)
+
+    task = PipelineTask('task_name', myfunc, context_kwargs={'ctx': 'ctx_in'})
+    wrapper = get_stream_wrapper(task, {'ctx': 'test_ctx'})
+    dfs = [pipelinestartdf, pipelinestartdf.assign(batch_id = 1)]
+    res_len, res_df = wrapper(*dfs)
+    assert res_len == 2 == len(res_df)
+
+
+def test_ray_steam_splitter_func():
+    df = pd.DataFrame({'id': range(10)})
+    ll = stream_split_func(df, 3)
+    lens = ll[:3]
+    df_list = ll[3:]
+    assert sum(lens) == 10 == sum(len(i) for i in df_list)
+    assert sorted(lens) == [3, 3, 4] == sorted(len(i) for i in df_list)
+    assert set(pd.concat(df_list)['id']) == set(df['id'])
+
+
+def test_ray_stream_ray_autoinit(monkeypatch, dummy_steps):
+    class raymock:
+        inited = False
+        def is_initialized(self):
+            return self.inited
+        def init(self):
+            self.inited = True
+    im = raymock()
+    monkeypatch.setattr(dplutils.pipeline.ray.ray, 'is_initialized', im.is_initialized)
+    monkeypatch.setattr(dplutils.pipeline.ray.ray, 'init', im.init)
+    pl = RayStreamGraphExecutor(dummy_steps)
+    assert not im.is_initialized()
+    next(pl.run())
+    assert im.is_initialized()

--- a/tests/pipeline/test_stream_executor.py
+++ b/tests/pipeline/test_stream_executor.py
@@ -1,0 +1,18 @@
+from dplutils.pipeline import PipelineTask
+from dplutils.pipeline.stream import LocalSerialExecutor, StreamTask
+from test_suite import PipelineExecutorTestSuite
+
+
+class TestStreamingExecutorDefault(PipelineExecutorTestSuite):
+    executor = LocalSerialExecutor
+
+
+def test_stream_task_wrapper():
+    st = StreamTask(PipelineTask('task_name', lambda x: 1))
+    assert st.name == 'task_name'
+    assert hash(st)  # ensure it is hashable
+    assert st.total_pending() == 0
+    st.data_in.append(1)
+    st.pending.append(1)
+    st.split_pending.append(1)
+    assert st.total_pending() == 3

--- a/tests/pipeline/test_stream_executor.py
+++ b/tests/pipeline/test_stream_executor.py
@@ -16,3 +16,11 @@ def test_stream_task_wrapper():
     st.pending.append(1)
     st.split_pending.append(1)
     assert st.total_pending() == 3
+
+
+def test_stream_exhausted_indicator_considers_splits(dummy_steps):
+    pl = LocalSerialExecutor(dummy_steps)
+    a_task = pl.stream_graph.task_map['task2']
+    assert pl.task_exhausted(a_task)
+    a_task.split_pending.append(1)
+    assert not pl.task_exhausted(a_task)

--- a/tests/pipeline/test_suite.py
+++ b/tests/pipeline/test_suite.py
@@ -1,0 +1,45 @@
+import pytest
+import pandas as pd
+
+
+@pytest.mark.parametrize('max_batches', (1, 4, 10))
+class PipelineExecutorTestSuite:
+    executor = None
+
+    def test_run_simple_pipeline_iterator(self, dummy_steps, max_batches):
+        pl = self.executor(dummy_steps, max_batches=max_batches)
+        it = pl.run()
+        for c in range(2):
+            if max_batches < c+1:
+                with pytest.raises(StopIteration):
+                    next(it)
+            else:
+                res = next(it)
+                assert isinstance(res, pd.DataFrame)
+                assert set(res.columns).issuperset({'id', 'step1', 'step2'})
+
+    def test_run_dag_pipeline(self, dummy_pipeline_graph, max_batches):
+        pl = self.executor(dummy_pipeline_graph, max_batches = max_batches)
+        it = pl.run()
+        total_df = pd.concat([b for b in it])
+        assert set(total_df.columns).issuperset({'id', 't1', 't2A', 't2B', 't3'})
+        # in this pipeline we don't expand the result size, but the forked dag adds
+        # another batch
+        assert len(total_df) == 2 * max_batches
+
+    def test_with_split_batch(self, dummy_steps, max_batches):
+        pl = self.executor(dummy_steps, max_batches=max_batches)
+        it = pl.set_config('task2.batch_size', 5).run()
+        res = list(it)
+        assert all([len(i) == 5 for i in res])
+        final = pd.concat(res)
+        assert final['id'].nunique() == max_batches
+
+    def test_with_merge_batch(self, dummy_steps, max_batches):
+        pl = self.executor(dummy_steps, max_batches=max_batches)
+        it = pl.set_config('task2.batch_size', 20).run()
+        res = list(it)
+        expected_len = 20 if max_batches > 1 else 10
+        assert all([len(i) == expected_len for i in res])
+        final = pd.concat(res)
+        assert final['id'].nunique() == max_batches


### PR DESCRIPTION
To overcome some drawbacks of ray data pipelines for the kinds of workloads we want:
* No support for streaming split. In the previous project, we wanted to have large batches for one process which fed to one that desired small batches. This could be faked, but at the expense that a write-out would wait for the whole batch, decreasing resilience
* No support for multiple inputs, or branching (Ray data only supports simple-path graphs). This could be simulated at the task level, but that leads to higher complexity and less portability in task code.
* Custom generators. These can be done in ray data but come with some drawbacks (also below)
* Indefinite generators. Ray data is designed more for data table ETL and less for streaming, so requires knowledge of total number of rows.

A few things that are out of scope here, but can be more easily integrated:
* Task result caching for resumption
* backpressure
* Implementation in different remote frameworks (example: parsl). The stream class handles most logic, the implementation just needs to manage resources, start tasks, and process results (e.g. see local serial implementation)

**Notes**:
* This ought to be backward compatible with the existing executor (it promotes list-of-tasks to graph)
* There is no join concept, multiple edges to a single task proceed in a package-sorter type of fashion. This supports tasks that are separate configurations of the same task, or tasks that produce compatible data products (e.g. different protein folding methods), and different outputs.
* Docs will be added in a separate PR - post-review