### PR TITLE
limit pandas version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,11 @@ description = ""
 readme = "README.md"
 license = {file = "LICENSE"}
 
-requires-python = ">=3.10"  # colabfold utilities expect this (for now)
+requires-python = ">=3.10,<3.12"  # prob can relax the lower limit...
 dependencies = [
-    "pandas",
+    "pandas<2.2",  # due to ray, track at: https://github.com/ray-project/ray/issues/42842
     "numpy",
-    "ray[default]",
+    "ray[data]",
     "pyarrow",
     "networkx",
 ]

--- a/requirements/prd.txt
+++ b/requirements/prd.txt
@@ -1,4 +1,4 @@
-ray[default]==2.9.1
+ray[default]==2.9.3
 async-timeout==4.0.3
 pandas==2.1.4
 pyarrow==14.0.2


### PR DESCRIPTION
(until ray publishes fix). Also, Ray[default] includes many things not actually required to use this package, so back down to a more limited set that is. Set python upper limit (really from ray, so maybe redundant)

see also: https://github.com/ray-project/ray/issues/42842