### PR TITLE
Tag outputs with task from which they came

### DIFF
--- a/dplutils/pipeline/__init__.py
+++ b/dplutils/pipeline/__init__.py
@@ -1,5 +1,5 @@
 from .task import PipelineTask
-from .executor import PipelineExecutor
+from .executor import PipelineExecutor, OutputBatch
 from .graph import PipelineGraph
 
-__all__ = ['PipelineTask', 'PipelineExecutor', 'PipelineGraph']
+__all__ = ['PipelineTask', 'PipelineExecutor', 'OutputBatch', 'PipelineGraph']

--- a/dplutils/pipeline/executor.py
+++ b/dplutils/pipeline/executor.py
@@ -131,8 +131,9 @@ class PipelineExecutor(ABC):
 
             task.func(prev_out_dataframe, **task.resolve_kwargs(self.context))
 
-        The method should return an iterator to the DataFrame batches of the
-        terminal tasks in the graph as they complete.
+        The method should return an iterator to the batches dataframes (stored
+        as :py:meth:`OutputBatch<OutputBatch>`s) of the terminal tasks in the
+        graph as they complete.
         """
         pass
 

--- a/dplutils/pipeline/executor.py
+++ b/dplutils/pipeline/executor.py
@@ -3,11 +3,18 @@ import pandas as pd
 import yaml
 from abc import ABC, abstractmethod
 from copy import deepcopy
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from collections.abc import Iterable
 from dplutils.pipeline.graph import PipelineGraph
 from dplutils.pipeline.utils import dict_from_coord
+
+
+@dataclass
+class OutputBatch:
+    data: pd.DataFrame
+    task: str = None
 
 
 class PipelineExecutor(ABC):
@@ -108,7 +115,7 @@ class PipelineExecutor(ABC):
         return self._run_id
 
     @abstractmethod
-    def execute(self) -> Iterable[pd.DataFrame]:
+    def execute(self) -> Iterable[OutputBatch]:
         """Execute the task graph in batches.
 
         This method must be overridden by implementations. It should arrange for
@@ -129,7 +136,7 @@ class PipelineExecutor(ABC):
         """
         pass
 
-    def run(self) -> Iterable[pd.DataFrame]:
+    def run(self) -> Iterable[OutputBatch]:
         """Validate and run the pipeline.
 
         Calls the ``self.execute`` method, and returns an iterator to batches as
@@ -139,11 +146,29 @@ class PipelineExecutor(ABC):
         self._run_id = None  # force reallocation
         return self.execute()
 
-    def writeto(self, outdir: Path|str) -> None:
+    def writeto(self, outdir: Path|str, partition_by_task: bool|None = None, task_partition_name: str = 'task') -> None:
         """Run pipeline, writing results to parquet table.
 
         args:
             outdir: path to the directory in which to write files
+            partition_by_task: If True, always create a hive-style partition by
+              the output task name in the output directory. If false, never
+              create such a partition. If None (default), create partitions if
+              there are multiple sink tasks, otherwise do not.
+            task_partition_name: name of the hive-style partition for
+              tasks. Default is task, e.g. create paths like
+              ``{outdir}/task={task}/...``
         """
+        if partition_by_task is None:
+            partition_by_task = False if len(self.graph.sink_tasks) == 1 else True
+
+        Path(outdir).mkdir(parents=True, exist_ok=True)
         for c, batch in enumerate(self.run()):
-            batch.to_parquet(Path(outdir) / f'{self.run_id}-{c}.parquet', index=False)
+            if partition_by_task:
+                part_name = batch.task or '__HIVE_DEFAULT_PARTITION__'
+                part_path = Path(outdir) / f'{task_partition_name}={part_name}'
+                part_path.mkdir(exist_ok=True)
+                outfile = part_path / f'{self.run_id}-{c}.parquet'
+            else:
+                outfile = Path(outdir) / f'{self.run_id}-{c}.parquet'
+            batch.data.to_parquet(outfile, index=False)

--- a/dplutils/pipeline/stream.py
+++ b/dplutils/pipeline/stream.py
@@ -6,7 +6,7 @@ from collections import deque
 from collections.abc import Generator
 from dataclasses import dataclass, field
 from typing import Any, Callable
-from dplutils.pipeline import PipelineTask, PipelineExecutor
+from dplutils.pipeline import PipelineTask, PipelineExecutor, OutputBatch
 from dplutils.pipeline.utils import deque_extract
 
 
@@ -44,7 +44,7 @@ class StreamTask:
         return self.task.name
 
     def total_pending(self):
-        return sum(len(i)  for i in [self.data_in, self.pending, self.split_pending])
+        return sum(len(i) for i in [self.data_in, self.pending, self.split_pending])
 
 
 class StreamingGraphExecutor(PipelineExecutor, ABC):
@@ -119,7 +119,7 @@ class StreamingGraphExecutor(PipelineExecutor, ABC):
             for ready in deque_extract(task.pending, self.is_task_ready):
                 block_info = self.task_resolve_output(ready)
                 if task in self.stream_graph.sink_tasks:
-                    return block_info.data
+                    return OutputBatch(block_info.data, task = task.name)
                 else:
                     for next_task in self.stream_graph.neighbors(task):
                         next_task.data_in.appendleft(block_info)

--- a/tests/pipeline/test_executor_base.py
+++ b/tests/pipeline/test_executor_base.py
@@ -53,13 +53,16 @@ def test_pipeline_executor_set_context(dummy_executor):
 
 
 def test_pipeline_executor_output_writer(dummy_executor, tmp_path):
-    dummy_executor.writeto(tmp_path)
+    dummy_executor.writeto(tmp_path, partition_by_task=False)
     for i in range(10):
         assert (tmp_path / f'{dummy_executor.run_id}-{i}.parquet').is_file()
     data = pd.read_parquet(tmp_path / f'{dummy_executor.run_id}-{i}.parquet')
     # these test the expected data inside each batch, hence len fixed at 10
     assert len(data) == 10
     assert len(data.id) == 10
+    dummy_executor.writeto(tmp_path, partition_by_task=True)
+    for i in range(10):
+        assert (tmp_path / 'task=task2' / f'{dummy_executor.run_id}-{i}.parquet').is_file()
 
 
 def test_pipeline_executor_from_list_graph(dummy_executor, dummy_steps):

--- a/tests/pipeline/test_ray_executor.py
+++ b/tests/pipeline/test_ray_executor.py
@@ -1,7 +1,7 @@
 import ray
 import pandas as pd
 import pytest
-from dplutils.pipeline import  PipelineTask
+from dplutils.pipeline import  PipelineTask, OutputBatch
 from dplutils.pipeline.ray import RayDataPipelineExecutor, get_remote_wrapper, set_run_id
 from dplutils import observer
 from dplutils.observer.ray import RayActorWrappedObserver, RayMetricsObserver
@@ -69,7 +69,7 @@ def test_pipeline_create_returns_ray_dataset(dummy_ray_pipeline, raysession):
 
 def test_pipeline_run_dummy_runs_steps_and_generates_outputs(dummy_ray_pipeline, raysession):
     it = dummy_ray_pipeline.run()
-    batch1 = next(it)
+    batch1 = next(it).data
     assert isinstance(batch1, pd.DataFrame)
     assert batch1['run_id'].iloc[0] == dummy_ray_pipeline.run_id
     assert len(batch1) == 10
@@ -77,7 +77,7 @@ def test_pipeline_run_dummy_runs_steps_and_generates_outputs(dummy_ray_pipeline,
     assert batch1['step1'].iloc[0] == 1
     # the other steps should see that batch size
     if dummy_ray_pipeline.n_batches > 1:
-        batch2 = next(it)
+        batch2 = next(it).data
         assert batch1['batch_id'].iloc[0] != batch2['batch_id'].iloc[0]
         assert len(batch2) == 10
         assert batch2['step2'].iloc[0] == 10
@@ -95,8 +95,10 @@ def test_pipeline_splits_tasks_into_separate_remotes_with_context(raysession, te
         PipelineTask('task', task_func, context_kwargs={'ctxdata': 'testfile'}, batch_size=10)
     ]).set_context('testfile', test_file).run()
     batch = next(it)
-    assert len(set(batch['task_id'])) == 10
-    assert batch['ctxdata'].iloc[0] == 'TESTDATA\n'
+    assert isinstance(batch, OutputBatch)
+    assert batch.task == 'task'
+    assert len(set(batch.data['task_id'])) == 10
+    assert batch.data['ctxdata'].iloc[0] == 'TESTDATA\n'
 
 
 def test_pipeline_non_split_task_has_access_to_context(raysession, test_file):
@@ -106,7 +108,7 @@ def test_pipeline_non_split_task_has_access_to_context(raysession, test_file):
     it = RayDataPipelineExecutor([
         PipelineTask('task', task_func, context_kwargs={'ctxdata': 'testfile'})
     ]).set_context('testfile', test_file).run()
-    batch = next(it)
+    batch = next(it).data
     assert batch['ctxdata'].iloc[0] == 'TESTDATA\n'
 
 

--- a/tests/pipeline/test_stream_executor.py
+++ b/tests/pipeline/test_stream_executor.py
@@ -36,7 +36,7 @@ def test_stream_executor_generator_override(max_batches):
         for i in range(n):
             yield pd.DataFrame({'customgen': [i]})
     pl = LocalSerialExecutor([st], max_batches=max_batches, generator=generator)
-    res = list(pl.run())
+    res = list(i.data for i in pl.run())
     expected_rows = max_batches if max_batches else 12
     assert len(res) == expected_rows
     assert pd.concat(res).customgen.to_list() == list(range(expected_rows))

--- a/tests/pipeline/test_suite.py
+++ b/tests/pipeline/test_suite.py
@@ -1,5 +1,6 @@
 import pytest
 import pandas as pd
+from dplutils.pipeline import OutputBatch
 
 
 @pytest.mark.parametrize('max_batches', (1, 4, 10))
@@ -15,24 +16,52 @@ class PipelineExecutorTestSuite:
                     next(it)
             else:
                 res = next(it)
-                assert isinstance(res, pd.DataFrame)
-                assert set(res.columns).issuperset({'id', 'step1', 'step2'})
+                assert isinstance(res, OutputBatch)
+                assert res.task == 'task2'
+                assert isinstance(res.data, pd.DataFrame)
+                assert set(res.data.columns).issuperset({'id', 'step1', 'step2'})
 
     def test_run_dag_pipeline(self, dummy_pipeline_graph, max_batches):
         pl = self.executor(dummy_pipeline_graph, max_batches = max_batches)
         it = pl.run()
-        total_df = pd.concat([b for b in it])
+        total_df = pd.concat([b.data for b in it])
         assert set(total_df.columns).issuperset({'id', 't1', 't2A', 't2B', 't3'})
         # in this pipeline we don't expand the result size, but the forked dag adds
         # another batch
         assert len(total_df) == 2 * max_batches
 
+    @pytest.mark.parametrize('partition_by_task', [None, True, False])
+    @pytest.mark.parametrize('graph_type, factor', [('dummy_steps', 1), ('dummy_pipeline_graph', 2), ('multi_output_graph', 2)])
+    def test_write_pipeline(self, partition_by_task, graph_type, factor, graph_suite, tmp_path, max_batches):
+        pl = self.executor(graph_suite[graph_type], max_batches=max_batches)
+        pl.writeto(tmp_path, partition_by_task=partition_by_task)
+        # these two graphs have only one output
+        if graph_type in ['dummy_steps', 'dummy_pipeline_graph']:
+            sink = pl.graph.sink_tasks[0].name
+            part_path = tmp_path / f'task={sink}'
+            if partition_by_task is None or not partition_by_task:
+                assert not part_path.exists() and not part_path.is_dir()
+                assert len(list(tmp_path.glob('*.parquet'))) == max_batches*factor
+            else:
+                assert part_path.is_dir()
+                assert len(list(part_path.glob('*.parquet'))) == max_batches*factor
+        # other graph has multiple outputs:
+        else:
+            sinks = [i.name for i in pl.graph.sink_tasks]
+            if partition_by_task is False:
+                assert len(list(tmp_path.glob('*.parquet'))) == max_batches*factor
+            else:
+                for sink in sinks:
+                    part_path = tmp_path / f'task={sink}'
+                    assert part_path.is_dir()
+                    assert len(list(part_path.glob('*.parquet'))) == max_batches
+
     def test_with_split_batch(self, dummy_steps, max_batches):
         pl = self.executor(dummy_steps, max_batches=max_batches)
         it = pl.set_config('task2.batch_size', 5).run()
         res = list(it)
-        assert all([len(i) == 5 for i in res])
-        final = pd.concat(res)
+        assert all([len(i.data) == 5 for i in res])
+        final = pd.concat([i.data for i in res])
         assert final['id'].nunique() == max_batches
 
     def test_with_merge_batch(self, dummy_steps, max_batches):
@@ -40,6 +69,6 @@ class PipelineExecutorTestSuite:
         it = pl.set_config('task2.batch_size', 20).run()
         res = list(it)
         expected_len = 20 if max_batches > 1 else 10
-        assert all([len(i) == expected_len for i in res])
-        final = pd.concat(res)
+        assert all([len(i.data) == expected_len for i in res])
+        final = pd.concat([i.data for i in res])
         assert final['id'].nunique() == max_batches


### PR DESCRIPTION
To enable partitioning outputs by the task that emitted them. This comes with a breaking change in the interface to executor, since it now emits OutputBatch instead of dataframe, but this seems low risk at the moment, and any users of writeto will remain back-compatible. The OutputBatch structure (as opposed to tuple, for instance) was chosen to enable future metadata additions.

Resolves https://github.com/ssec-jhu/dplutils/issues/61