### PR TITLE
Skip zero-length batches in stream executor

### DIFF
--- a/dplutils/pipeline/stream.py
+++ b/dplutils/pipeline/stream.py
@@ -124,6 +124,8 @@ class StreamingGraphExecutor(PipelineExecutor, ABC):
         for task in self.stream_graph.walk_fwd():
             for ready in deque_extract(task.pending, self.is_task_ready):
                 block_info = self.task_resolve_output(ready)
+                if block_info.length == 0:
+                    continue
                 if task in self.stream_graph.sink_tasks:
                     return OutputBatch(block_info.data, task=task.name)
                 else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,11 @@ def dummy_steps():
 
 
 @pytest.fixture
+def blackhole_step():
+    return [PipelineTask("blackhole", func=lambda x: pd.DataFrame([]))]
+
+
+@pytest.fixture
 def dummy_pipeline_graph():
     t1 = PipelineTask("task1", lambda x: x.assign(t1="1"))
     t2A = PipelineTask("task2A", lambda x: x.assign(t2A="2A"))


### PR DESCRIPTION
Zero length data batches risk starting tasks and serializing data unnecessarily, consuming resources for batches that ultimately would not be expected to yield any data.

Resolves https://github.com/ssec-jhu/dplutils/issues/62