### PR TITLE
Improve support for pipeline config from file

### DIFF
--- a/dplutils/cli.py
+++ b/dplutils/cli.py
@@ -17,6 +17,7 @@ def add_generic_args(argparser):
         argparser: The :class:`ArgumentParser<argparse.ArgumentParser>` instance
           to add args to.
     """
+    argparser.add_argument("-f", "--file", default=None, help="path of yaml pipeline config file")
     argparser.add_argument("-c", "--set-context", action="append", default=[], help="set context parameter")
     argparser.add_argument("-s", "--set-config", action="append", default=[], help="set configuration parameter")
     argparser.add_argument("-o", "--out-dir", default=".", help="write results to directory")
@@ -52,9 +53,11 @@ def parse_config_element(conf):
 def set_config_from_args(pipeline: PipelineExecutor, args: Namespace):
     """Configure pipeline using config from arguments
 
-    Set context from the ``set-context`` argument and config from
-    ``set-config``. Each will be parset as ``name=value`` pair, where the value
-    is parsed as a JSON object, falling back to string.
+    Set context from the ``set-context`` argument and config from ``set-config``
+    and both from config file given in ``file``. Config file will be applied
+    first so that specific context and config settings on the command line will
+    override settings in the file. Each will be parsed as  ``name=value`` pair,
+    where the value is parsed as a JSON object, falling back to string.
 
     For ``set-config``, the ``name`` is of the form
     ``task.param[.subparam[...]]`` where ``task`` is the taskname, ``param`` is
@@ -62,6 +65,8 @@ def set_config_from_args(pipeline: PipelineExecutor, args: Namespace):
     and ``subparam`` is a key within a dictionary of such a parameter (where
     applicable).
     """
+    if args.file is not None:
+        pipeline.set_config(from_yaml=args.file)
     for ctx in args.set_context:
         pipeline.set_context(*parse_config_element(ctx))
     for conf in args.set_config:

--- a/dplutils/cli.py
+++ b/dplutils/cli.py
@@ -9,6 +9,7 @@ def add_generic_args(argparser):
 
     The generic set of CLI arguments are as follows:
 
+        - ``-f`` (``--file``): set configuration and context from specified yaml file.
         - ``-c`` (``--set-context``): Set pipline context item.
         - ``-s`` (``--set-config``): Set pipline config item.
         - ``-o`` (``--out-dir``): Directory to write output files to.

--- a/tests/pipeline/test_executor_base.py
+++ b/tests/pipeline/test_executor_base.py
@@ -29,16 +29,21 @@ def test_pipeline_executor_set_config_from_coord(dummy_executor):
 def test_pipeline_executor_set_config_from_file(dummy_executor, tmp_path):
     config_file = tmp_path / "config.yaml"
     config_file.write_text("""
-    task1:
-      num_gpus: 1
-      kwargs:
-        test: 1
+    context:
+        testcontext: ctxvalue
+    config:
+      task1:
+        num_gpus: 1
+        kwargs:
+          test: 1
     """)
     assert dummy_executor.tasks_idx["task1"].num_gpus != 1
     assert dummy_executor.tasks_idx["task1"].kwargs != {"test": 1}
+    assert "testcontext" not in dummy_executor.ctx
     dummy_executor.set_config(from_yaml=config_file)
     assert dummy_executor.tasks_idx["task1"].num_gpus == 1
     assert dummy_executor.tasks_idx["task1"].kwargs == {"test": 1}
+    assert dummy_executor.ctx["testcontext"] == "ctxvalue"
 
 
 def test_pipeline_config_raises_when_no_kwargs(dummy_executor):

--- a/tests/pipeline/test_executor_base.py
+++ b/tests/pipeline/test_executor_base.py
@@ -1,3 +1,5 @@
+from textwrap import dedent
+
 import pandas as pd
 import pytest
 
@@ -28,7 +30,8 @@ def test_pipeline_executor_set_config_from_coord(dummy_executor):
 
 def test_pipeline_executor_set_config_from_file(dummy_executor, tmp_path):
     config_file = tmp_path / "config.yaml"
-    config_file.write_text("""
+    config_file.write_text(
+        dedent("""
     context:
         testcontext: ctxvalue
     config:
@@ -37,6 +40,7 @@ def test_pipeline_executor_set_config_from_file(dummy_executor, tmp_path):
         kwargs:
           test: 1
     """)
+    )
     assert dummy_executor.tasks_idx["task1"].num_gpus != 1
     assert dummy_executor.tasks_idx["task1"].kwargs != {"test": 1}
     assert "testcontext" not in dummy_executor.ctx


### PR DESCRIPTION
Add cli option for config from yaml file given on command line. Also change the file format to enable context to likewise be configured using separate sections in config. This is a breaking change, but resolution is simple and impact should be very low due to limited existing usage.

Resolves https://github.com/ssec-jhu/dplutils/issues/64
