### PR TITLE
Fix bug in task validation to handle variadic args

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,5 +94,21 @@ def generic_task_with_required():
 
 
 @pytest.fixture
+def generic_task_with_starkwargs():
+    def func(dataframe, **kwargs):
+        pass
+
+    return PipelineTask("name", func)
+
+
+@pytest.fixture
+def generic_task_with_position_only():
+    def func(dataframe, position_only, /):
+        pass
+
+    return PipelineTask("name", func)
+
+
+@pytest.fixture
 def dummy_executor(dummy_steps):
     return DummyExecutor(graph=dummy_steps)

--- a/tests/pipeline/test_pipeline_task.py
+++ b/tests/pipeline/test_pipeline_task.py
@@ -40,5 +40,19 @@ def test_pipeline_task_check_kwargs_from_context(generic_task_with_required):
 
 
 def test_pipeline_task_check_kwargs_from_context_raises_with_missing(generic_task_with_required):
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="expected from context"):
         generic_task_with_required(context_kwargs={"required": "ctx_required"}).validate({})
+
+
+def test_pipeline_task_with_starkwargs_argument_allows_any(generic_task_with_starkwargs):
+    generic_task_with_starkwargs(kwargs={"some_kwarg": 1}).validate({})
+
+
+def test_pipeline_task_with_first_arg_as_kwarg_raises(generic_task_with_starkwargs):
+    with pytest.raises(ValueError, match="first position argument reserved"):
+        generic_task_with_starkwargs(kwargs={"dataframe": 1}).validate({})
+
+
+def test_pipeline_task_with_multiple_position_only_raises(generic_task_with_position_only):
+    with pytest.raises(ValueError, match="only one positional only"):
+        generic_task_with_position_only().validate({})


### PR DESCRIPTION
This also handles the case of multiple positional only args - since we only support a single one which is the input dataframe - and where a keyword argument overlaps with this first argument.

resolves https://github.com/ssec-jhu/dplutils/issues/97