### PR TITLE
Fix streaming input for batch and multiple sources

### DIFF
--- a/dplutils/pipeline/stream.py
+++ b/dplutils/pipeline/stream.py
@@ -65,8 +65,10 @@ class StreamingGraphExecutor(PipelineExecutor, ABC):
           to the input task(s). Default is None, which means either exhaust the
           source generator or run indefinitely.
         generator: A callable that when called returns a generator which yields
-          dataframes. The yielded dataframes are assumed to be a single row, in
-          which case input task batching will be honored.
+          dataframes. The driver will call ``len()`` on the yielded dataframes to
+          obtain the number of rows and will split and batch according to the input
+          task settings. Each generated dataframe, regardless of size, counts as
+          a single source batch with respect to ``max_batches``.
 
 
     Implementations must override abstract methods for (remote) task submission

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,14 @@ def multi_output_graph():
 
 
 @pytest.fixture
+def multi_source_graph():
+    t1A = PipelineTask("srcA", lambda x: x.assign(a="A"))
+    t1B = PipelineTask("srcB", lambda x: x.assign(b="B"))
+    t2 = PipelineTask("sink", lambda x: x.assign(sink="sink"))
+    return PipelineGraph([(t1A, t2), (t1B, t2)])
+
+
+@pytest.fixture
 def graph_suite(dummy_steps, dummy_pipeline_graph, multi_output_graph):
     return {
         "dummy_steps": dummy_steps,


### PR DESCRIPTION
This fixes the behavior of multiple source tasks to match that of a branched task (broadcast outputs to children). It also adds support for generated input of length > 1 to be handled as expected included possibly splitting the batch.

Resolves https://github.com/ssec-jhu/dplutils/issues/60
Resolves https://github.com/ssec-jhu/dplutils/issues/76