### PR TITLE
Add pipeline-specific help info

### DIFF
--- a/dplutils/cli.py
+++ b/dplutils/cli.py
@@ -99,7 +99,7 @@ def cli_run(pipeline: PipelineExecutor, args: Namespace | None = None, **argpars
         args = get_argparser(**argparse_kwargs).parse_args()
     set_config_from_args(pipeline, args)
     if args.info:
-        print(pipeline.describe())
+        print(pipeline)
         print("Set task parameters with --set-config, context with --set-context")
         print("See --help for more options")
         return

--- a/dplutils/cli.py
+++ b/dplutils/cli.py
@@ -100,5 +100,7 @@ def cli_run(pipeline: PipelineExecutor, args: Namespace | None = None, **argpars
     set_config_from_args(pipeline, args)
     if args.info:
         print(pipeline.describe())
+        print("Set task parameters with --set-config, context with --set-context")
+        print("See --help for more options")
         return
     pipeline.writeto(args.out_dir)

--- a/dplutils/cli.py
+++ b/dplutils/cli.py
@@ -9,6 +9,7 @@ def add_generic_args(argparser):
 
     The generic set of CLI arguments are as follows:
 
+        - ``-i`` (``--info``): show detailed info about pipeline and tasks.
         - ``-f`` (``--file``): set configuration and context from specified yaml file.
         - ``-c`` (``--set-context``): Set pipline context item.
         - ``-s`` (``--set-config``): Set pipline config item.
@@ -18,7 +19,7 @@ def add_generic_args(argparser):
         argparser: The :class:`ArgumentParser<argparse.ArgumentParser>` instance
           to add args to.
     """
-    argparser.add_argument("--info", action="store_true", help="show detailed info about pipeline and tasks")
+    argparser.add_argument("-i", "--info", action="store_true", help="show detailed info about pipeline and tasks")
     argparser.add_argument("-f", "--file", default=None, help="path of yaml pipeline config file")
     argparser.add_argument("-c", "--set-context", action="append", default=[], help="set context parameter")
     argparser.add_argument("-s", "--set-config", action="append", default=[], help="set configuration parameter")

--- a/dplutils/cli.py
+++ b/dplutils/cli.py
@@ -18,6 +18,7 @@ def add_generic_args(argparser):
         argparser: The :class:`ArgumentParser<argparse.ArgumentParser>` instance
           to add args to.
     """
+    argparser.add_argument("--info", action="store_true", help="show detailed info about pipeline and tasks")
     argparser.add_argument("-f", "--file", default=None, help="path of yaml pipeline config file")
     argparser.add_argument("-c", "--set-context", action="append", default=[], help="set context parameter")
     argparser.add_argument("-s", "--set-config", action="append", default=[], help="set configuration parameter")
@@ -96,4 +97,7 @@ def cli_run(pipeline: PipelineExecutor, args: Namespace | None = None, **argpars
     if args is None:
         args = get_argparser(**argparse_kwargs).parse_args()
     set_config_from_args(pipeline, args)
+    if args.info:
+        print(pipeline.describe())
+        return
     pipeline.writeto(args.out_dir)

--- a/dplutils/pipeline/executor.py
+++ b/dplutils/pipeline/executor.py
@@ -1,3 +1,4 @@
+import itertools
 import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
@@ -45,6 +46,20 @@ class PipelineExecutor(ABC):
     @property
     def tasks_idx(self):  # for back compat
         return self.graph.task_map
+
+    def describe(self) -> str:
+        desc = "Tasks:\n" + "\n".join([f"  - {task}" for task in self.graph]) + "\n"
+        required_context = set(itertools.chain.from_iterable(task.context_kwargs.keys() for task in self.graph)).union(
+            self.ctx.keys()
+        )
+        if required_context:
+            desc += "Required context:\n"
+            for key in sorted(required_context):
+                desc += f"  - {key}"
+                if key in self.ctx:
+                    desc += f" (set to {self.ctx[key]})"
+                desc += "\n"
+        return desc
 
     def set_context(self, key, value) -> "PipelineExecutor":
         self.ctx[key] = value

--- a/dplutils/pipeline/executor.py
+++ b/dplutils/pipeline/executor.py
@@ -39,15 +39,7 @@ class PipelineExecutor(ABC):
         self.ctx = {}
         self._run_id = None
 
-    @classmethod
-    def from_graph(cls, graph: PipelineGraph) -> "PipelineExecutor":
-        return cls(graph)
-
-    @property
-    def tasks_idx(self):  # for back compat
-        return self.graph.task_map
-
-    def describe(self) -> str:
+    def __str__(self) -> str:
         desc = "Tasks:\n" + "\n".join([f"  - {task}" for task in self.graph]) + "\n"
         required_context = set(itertools.chain.from_iterable(task.context_kwargs.keys() for task in self.graph)).union(
             self.ctx.keys()
@@ -60,6 +52,14 @@ class PipelineExecutor(ABC):
                     desc += f" (set to {self.ctx[key]})"
                 desc += "\n"
         return desc
+
+    @classmethod
+    def from_graph(cls, graph: PipelineGraph) -> "PipelineExecutor":
+        return cls(graph)
+
+    @property
+    def tasks_idx(self):  # for back compat
+        return self.graph.task_map
 
     def set_context(self, key, value) -> "PipelineExecutor":
         self.ctx[key] = value

--- a/tests/pipeline/test_executor_base.py
+++ b/tests/pipeline/test_executor_base.py
@@ -90,3 +90,19 @@ def test_validate_records_and_raises_errors(dummy_executor):
 
     with pytest.raises(ValueError, match="Errors in validation"):
         dummy_executor.validate()
+
+
+def test_executor_describe(dummy_executor):
+    description = dummy_executor.describe()
+    assert "task1" in description
+    assert "task2" in description
+    assert "Required context" not in description
+    # add in context to test representation for that, render only when context is required by a task
+    dummy_executor.tasks_idx["task1"].context_kwargs = {"testcontext": "test"}
+    description = dummy_executor.describe()
+    assert "Required context" in description
+    assert "testcontext" in description
+    dummy_executor.ctx = {"testcontext": "testvalue", "contextnotintask": "testvaluenotintask"}
+    description = dummy_executor.describe()
+    assert "(set to testvalue)" in description
+    assert "contextnotintask" in description

--- a/tests/pipeline/test_executor_base.py
+++ b/tests/pipeline/test_executor_base.py
@@ -93,16 +93,16 @@ def test_validate_records_and_raises_errors(dummy_executor):
 
 
 def test_executor_describe(dummy_executor):
-    description = dummy_executor.describe()
+    description = str(dummy_executor)
     assert "task1" in description
     assert "task2" in description
     assert "Required context" not in description
     # add in context to test representation for that, render only when context is required by a task
     dummy_executor.tasks_idx["task1"].context_kwargs = {"testcontext": "test"}
-    description = dummy_executor.describe()
+    description = str(dummy_executor)
     assert "Required context" in description
     assert "testcontext" in description
     dummy_executor.ctx = {"testcontext": "testvalue", "contextnotintask": "testvaluenotintask"}
-    description = dummy_executor.describe()
+    description = str(dummy_executor)
     assert "(set to testvalue)" in description
     assert "contextnotintask" in description

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -111,5 +111,5 @@ def test_cli_pipeline_info(monkeypatch, tmp_path, dummy_executor):
     sio = StringIO()
     monkeypatch.setattr("sys.stdout", sio)
     cli.cli_run(dummy_executor)
-    assert dummy_executor.describe() in sio.getvalue()
+    assert str(dummy_executor) in sio.getvalue()
     assert len(list(tmp_path.glob("*.parquet"))) == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -111,5 +111,5 @@ def test_cli_pipeline_info(monkeypatch, tmp_path, dummy_executor):
     sio = StringIO()
     monkeypatch.setattr("sys.stdout", sio)
     cli.cli_run(dummy_executor)
-    assert sio.getvalue().strip() == dummy_executor.describe().strip()
+    assert dummy_executor.describe() in sio.getvalue()
     assert len(list(tmp_path.glob("*.parquet"))) == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+from io import StringIO
 from textwrap import dedent
 
 import pytest
@@ -103,3 +104,12 @@ def test_run_with_cli_helper(monkeypatch, dummy_executor, tmp_path):
     assert dummy_executor.tasks_idx["task_kw"].kwargs["b"] == 99
     assert dummy_executor.tasks_idx["task_kw"].num_cpus == 0.5
     assert len(list(tmp_path.glob("*.parquet"))) == 10
+
+
+def test_cli_pipeline_info(monkeypatch, tmp_path, dummy_executor):
+    monkeypatch.setattr("sys.argv", ["", "--info", "-o", str(tmp_path)])
+    sio = StringIO()
+    monkeypatch.setattr("sys.stdout", sio)
+    cli.cli_run(dummy_executor)
+    assert sio.getvalue().strip() == dummy_executor.describe().strip()
+    assert len(list(tmp_path.glob("*.parquet"))) == 0


### PR DESCRIPTION
Create a string representation of pipeline including information on tasks and required context variables. This also adds the CLI utilities to display this info using the `-i`, `--info` switch. 

This will enable users to more easily see what tasks names are and context to set using switches on command line. 

An example:

```
Tasks:
  - PipelineTask(name='task1', func=<function dummy_steps.<locals>.<lambda> at 0x16be9c2c0>, context_kwargs={'testcontext': 'test'}, kwargs={}, num_gpus=None, num_cpus=1, resources={}, batch_size=None)
  - PipelineTask(name='task2', func=<function dummy_steps.<locals>.<lambda> at 0x16be9c360>, context_kwargs={}, kwargs={}, num_gpus=None, num_cpus=1, resources={}, batch_size=None)
Required context:
  - contextnotintask (set to testvaluenotintask)
  - testcontext (set to testvalue)

Set task parameters with --set-config, context with --set-context
See --help for more options
```

this resolves #101 