### PR TITLE
add some infrastructure logging for executors

### DIFF
--- a/dplutils/cli.py
+++ b/dplutils/cli.py
@@ -1,7 +1,10 @@
 import json
+import logging
 from argparse import ArgumentParser, Namespace
 
 from dplutils.pipeline import PipelineExecutor
+
+LOG_FORMAT = "%(asctime)s (%(name)s) [%(levelname)s]: %(message)s"
 
 
 def add_generic_args(argparser):
@@ -14,6 +17,7 @@ def add_generic_args(argparser):
         - ``-c`` (``--set-context``): Set pipline context item.
         - ``-s`` (``--set-config``): Set pipline config item.
         - ``-o`` (``--out-dir``): Directory to write output files to.
+        - ``-v`` (``--verbosity``): Verbosity level for logging (default INFO).
 
     Args:
         argparser: The :class:`ArgumentParser<argparse.ArgumentParser>` instance
@@ -24,6 +28,7 @@ def add_generic_args(argparser):
     argparser.add_argument("-c", "--set-context", action="append", default=[], help="set context parameter")
     argparser.add_argument("-s", "--set-config", action="append", default=[], help="set configuration parameter")
     argparser.add_argument("-o", "--out-dir", default=".", help="write results to directory")
+    argparser.add_argument("-v", "--verbosity", default="INFO", help="logging verbosity level")
 
 
 def get_argparser(**kwargs):
@@ -76,6 +81,16 @@ def set_config_from_args(pipeline: PipelineExecutor, args: Namespace):
         pipeline.set_config(*parse_config_element(conf))
 
 
+def setup_logging(level):
+    """Set up logging for the pipeline
+
+    This function sets up logging for the pipeline, using the standard
+    python logging module. The level is set to the value of the
+    ``verbosity`` argument.
+    """
+    logging.basicConfig(level=level, format=LOG_FORMAT, force=True)
+
+
 def cli_run(pipeline: PipelineExecutor, args: Namespace | None = None, **argparse_kwargs):
     """Run pipeline from cli args
 
@@ -103,4 +118,5 @@ def cli_run(pipeline: PipelineExecutor, args: Namespace | None = None, **argpars
         print("Set task parameters with --set-config, context with --set-context")
         print("See --help for more options")
         return
+    setup_logging(args.verbosity)
     pipeline.writeto(args.out_dir)

--- a/dplutils/cli.py
+++ b/dplutils/cli.py
@@ -84,9 +84,8 @@ def set_config_from_args(pipeline: PipelineExecutor, args: Namespace):
 def setup_logging(level):
     """Set up logging for the pipeline
 
-    This function sets up logging for the pipeline, using the standard
-    python logging module. The level is set to the value of the
-    ``verbosity`` argument.
+    This function sets up logging for the pipeline, using the standard python
+    logging module. The level is set to the value of the ``verbosity`` argument.
     """
     logging.basicConfig(level=level, format=LOG_FORMAT, force=True)
 

--- a/dplutils/pipeline/executor.py
+++ b/dplutils/pipeline/executor.py
@@ -1,4 +1,5 @@
 import itertools
+import logging
 import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
@@ -38,6 +39,7 @@ class PipelineExecutor(ABC):
             self.graph = deepcopy(graph)
         self.ctx = {}
         self._run_id = None
+        self.logger = logging.getLogger(f"dplutils.{self.__class__.__name__}")
 
     def __str__(self) -> str:
         desc = "Tasks:\n" + "\n".join([f"  - {task}" for task in self.graph]) + "\n"
@@ -200,4 +202,5 @@ class PipelineExecutor(ABC):
                 outfile = part_path / f"{self.run_id}-{c}.parquet"
             else:
                 outfile = Path(outdir) / f"{self.run_id}-{c}.parquet"
+            self.logger.debug(f"Writing output <{batch.task}>[l={len(batch.data)};c={c}] to {outfile}")
             batch.data.to_parquet(outfile, index=False)

--- a/dplutils/pipeline/executor.py
+++ b/dplutils/pipeline/executor.py
@@ -11,6 +11,7 @@ from typing import Any
 import pandas as pd
 import yaml
 
+from dplutils import __project__
 from dplutils.pipeline.graph import PipelineGraph
 from dplutils.pipeline.utils import dict_from_coord
 
@@ -39,7 +40,7 @@ class PipelineExecutor(ABC):
             self.graph = deepcopy(graph)
         self.ctx = {}
         self._run_id = None
-        self.logger = logging.getLogger(f"dplutils.{self.__class__.__name__}")
+        self.logger = logging.getLogger(f"{__project__}.{self.__class__.__name__}")
 
     def __str__(self) -> str:
         desc = "Tasks:\n" + "\n".join([f"  - {task}" for task in self.graph]) + "\n"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,9 @@ def test_file(tmp_path_factory):
 
 class DummyExecutor(PipelineExecutor):
     def execute(self):
+        self.logger.info("Executing dummy executor")
         for i in range(10):
+            self.logger.debug(f"Yielding batch {i}")
             yield OutputBatch(pd.DataFrame({"id": range(10)}), task=self.graph.sink_tasks[0].name)
 
 


### PR DESCRIPTION
Adding some debug logging to pipeline infrastructure. Also adding basic cli settings for logging. 

For ray this would work for driver logs, we can either add some guidance on setting up logging from workers, and/or have some utility functions for those, or some options within the ray-based executor to inject in wrapper functions. Leaving that out of scope for now.