### PR TITLE
fixing walk order to resolve priority in multi-sink pipelines

### DIFF
--- a/dplutils/pipeline/stream.py
+++ b/dplutils/pipeline/stream.py
@@ -215,6 +215,8 @@ class StreamingGraphExecutor(PipelineExecutor, ABC):
                 eligible, submitted = _handle_one_task(task, rank)
                 if eligible:  # update rank of this task if it _could_ be done, whether or not it was
                     rank += 1
+                if submitted:
+                    break
 
         # Source as many inputs as can fit on source tasks. We prioritize flushing the
         # input queue and secondarily on number of invocations in case batch sizes differ.

--- a/tests/pipeline/test_stream_executor.py
+++ b/tests/pipeline/test_stream_executor.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 import pandas as pd
 import pytest
 from test_suite import PipelineExecutorTestSuite
@@ -77,3 +79,47 @@ def test_stream_executor_input_batch_size_splits(dummy_steps):
     pl = LocalSerialExecutor(dummy_steps, generator=generator).set_config("task1.batch_size", 1)
     res = [i.data for i in pl.run()]
     assert len(res) == 8
+
+
+def test_stream_submission_ordering_evaluation_priority():
+    # tracking class adds counts and a parallel submission which allows us to
+    # locally test that the re-prioritization during submission is working. If
+    # so, we should expect terminal tasks having even numbers of calls and being
+    # preferred (as opposed to submitting n parallel all to one task, or
+    # submitting some to upstream tasks).
+    class MyExec(LocalSerialExecutor):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.counts = defaultdict(int)
+            self.parallel_submissions = 4
+            self.n_parallel = 0
+
+        def task_submit(self, task, data):
+            self.counts[task.name] += 1
+            self.n_parallel += 1
+            return super().task_submit(task, data)
+
+        def task_submittable(self, t, rank):
+            if t in self.graph.source_tasks:
+                return True
+            return self.n_parallel < self.parallel_submissions
+
+        def poll_tasks(self, pending):
+            self.n_parallel = 0
+
+    a = PipelineTask("a", lambda x: x, batch_size=16)
+    b = a("b", batch_size=1)
+    (c, d, e) = (b("c"), b("d"), b("e"))
+    # graph with multiple terminals. The large input batch size ensures we have
+    # work to submit in parallel to exercise the re sorting logic.
+    p = MyExec([(a, b), (b, c), (c, d), (c, e)], max_batches=16)
+    p_run = p.run()
+    _ = [next(p_run) for _ in range(4)]  # pop number based on parallel submissions
+    assert p.counts["d"] == p.counts["e"] == 2  # terminals should have even counts
+    assert p.counts["b"] == p.counts["c"] == 4  # only just enough to submit 4
+    _ = [next(p_run) for _ in range(4)]
+    assert p.counts["d"] == p.counts["e"] == 4  # we finish the 4 batch size
+    assert p.counts["b"] == p.counts["c"] == 4  # but do no more upstream work
+    _ = [next(p_run) for _ in range(4)]
+    assert p.counts["d"] == p.counts["e"] == 6  # need to get more work, as above
+    assert p.counts["b"] == p.counts["c"] == 8  # more upstream for that work


### PR DESCRIPTION
When adding multiple sink tasks along the pipeline, it was observed that the further-along tasks do not end up getting priority to run, which could cause a pipeline to effectively run a path to a single output closer to the start and pile up a queue on downstream tasks. Looks like this is due to order of BFS search going backwards, which ends up at some nodes closer to start (following output closer to start) quicker.

Meaning for instance in the pipeline below, the green and yellow paths take more priority. Due to batch sizes, the green path would remain unscheduled, but the yellow path with single row batches and single cpu requests would simply keep taking priority and never submit the while tasks.

![image](https://github.com/user-attachments/assets/c3f450c4-0f5e-484e-bd2a-6a1e9557ac90)


The fix here is to penalize the tasks further from the sink along any path, at the same time the sink tasks are all considered the same rank, and thus we can continue to write out quickly. Any tasks at same rank are ordered as before (by execution count).

**Note**: This comes along with a small additional change: instead of submitting as many invocations of a particular task that fit at a time, we continue to evaluate the sort order, walking backward each time - this makes the pipeline "fairer" in a sense.