### PR TITLE
fixing bug in context info, reversed key/val

### DIFF
--- a/dplutils/pipeline/executor.py
+++ b/dplutils/pipeline/executor.py
@@ -44,9 +44,9 @@ class PipelineExecutor(ABC):
 
     def __str__(self) -> str:
         desc = "Tasks:\n" + "\n".join([f"  - {task}" for task in self.graph]) + "\n"
-        required_context = set(itertools.chain.from_iterable(task.context_kwargs.keys() for task in self.graph)).union(
-            self.ctx.keys()
-        )
+        required_context = set(
+            itertools.chain.from_iterable(task.context_kwargs.values() for task in self.graph)
+        ).union(self.ctx.keys())
         if required_context:
             desc += "Required context:\n"
             for key in sorted(required_context):

--- a/tests/pipeline/test_executor_base.py
+++ b/tests/pipeline/test_executor_base.py
@@ -98,11 +98,11 @@ def test_executor_describe(dummy_executor):
     assert "task2" in description
     assert "Required context" not in description
     # add in context to test representation for that, render only when context is required by a task
-    dummy_executor.tasks_idx["task1"].context_kwargs = {"testcontext": "test"}
+    dummy_executor.tasks_idx["task1"].context_kwargs = {"test": "testcontext"}
     description = str(dummy_executor)
     assert "Required context" in description
-    assert "testcontext" in description
+    assert "- testcontext" in description
     dummy_executor.ctx = {"testcontext": "testvalue", "contextnotintask": "testvaluenotintask"}
     description = str(dummy_executor)
-    assert "(set to testvalue)" in description
+    assert "- testcontext (set to testvalue)" in description
     assert "contextnotintask" in description


### PR DESCRIPTION
the context_kwargs is a mapping of `{"function_argument_name": "context_to_set_from"}`. This fixes a bug where the info method was collecting the "function_argument_name" and considering it an expected context variable, whereas it should be "context_to_set_from".