### PR TITLE
Wrapper naming that works for partials

### DIFF
--- a/dplutils/pipeline/ray.py
+++ b/dplutils/pipeline/ray.py
@@ -47,7 +47,8 @@ def get_remote_wrapper(task: PipelineTask, context: dict):
 
     # Ray data uses the function name to name the underlying remote tasks, override for the wrapper for better
     # observability
-    wrapper.__name__ = f"{task.name}<{task.func.__name__}>"
+    funcname = getattr(task.func, "__name__", task.func.__class__.__name__)
+    wrapper.__name__ = f"{task.name}<{funcname}>"
     return wrapper
 
 
@@ -178,11 +179,12 @@ class RayStreamGraphExecutor(StreamingGraphExecutor):
         # configuration and resources will be baked into the remote.
         self.remote_task_map = {}
         for name, task in self.graph.task_map.items():
+            funcname = getattr(task.func, "__name__", task.func.__class__.__name__)
             self.remote_task_map[name] = ray.remote(get_stream_wrapper(task, self.ctx)).options(
                 num_cpus=task.num_cpus,
                 num_gpus=task.num_gpus,
                 resources=task.resources,
-                name=f"{task.name}<{task.func.__name__}>",
+                name=f"{task.name}<{funcname}>",
                 num_returns=2,  # the remote wrapper returns (len of df, df)
             )
 

--- a/tests/pipeline/test_ray_executor.py
+++ b/tests/pipeline/test_ray_executor.py
@@ -1,3 +1,5 @@
+import functools
+
 import pandas as pd
 import pytest
 import ray
@@ -137,6 +139,15 @@ def test_remote_wrapper_sets_name_based_on_task_info():
 
     wrapper = get_remote_wrapper(PipelineTask("taskname", funcname), None)
     assert wrapper.__name__ == "taskname<funcname>"
+
+
+def test_remote_wrapper_sets_name_based_on_task_info_for_partials():
+    def original_funcname(x):
+        pass
+
+    new_funcname = functools.partial(original_funcname, 5)
+    wrapper = get_remote_wrapper(PipelineTask("taskname", new_funcname), None)
+    assert wrapper.__name__ == "taskname<partial>"
 
 
 @pytest.mark.parametrize("batch_size", [None, 1, 10])


### PR DESCRIPTION
I'm trying out [a dplutils task](https://github.com/alex-l-m/bluephos-task-example/blob/main/make_energy_task.py) where I define the function with partial application using functools.partial.

functools.partial returns objects of class "partial", which are callable, but don't have all the same attributes as functions defined the ordinary way.

This breaks dplutils wrapper naming, when using the ray executor. That code assumes the presence of a `__name__` attribute, which is safe for a function, but not for any callable.

I was curious how ray handles naming in these cases. It turns out that they have a lot of code that checks the class of callables. [For example](https://github.com/ray-project/ray/blob/0b2cfa046a720fdb77d22cd0d471566773000518/python/ray/data/_internal/logical/operators/map_operator.py),

```
def _get_operator_name(self, op_name: str, fn: UserDefinedFunction):
    """Gets the Operator name including the map `fn` UDF name."""
    # If the input `fn` is a Preprocessor, the
    # name is simply the name of the Preprocessor class.
    if inspect.ismethod(fn) and isinstance(fn.__self__, Preprocessor):
        return fn.__self__.__class__.__name__

    # Otherwise, it takes the form of `<MapOperator class>(<UDF name>)`,
    # e.g. `MapBatches(my_udf)`.
    try:
        if inspect.isclass(fn):
            # callable class
            return f"{op_name}({fn.__name__})"
        elif inspect.ismethod(fn):
            # class method
            return f"{op_name}({fn.__self__.__class__.__name__}.{fn.__name__})"
        elif inspect.isfunction(fn):
            # normal function or lambda function.
            return f"{op_name}({fn.__name__})"
        elif isinstance(fn, functools.partial):
            # functools.partial
            return f"{op_name}({fn.func.__name__})"
        else:
            # callable object.
            return f"{op_name}({fn.__class__.__name__})"
    except AttributeError as e:
        logger.error("Failed to get name of UDF %s: %s", fn, e)
        return "<unknown>"
```

I'm not sure it's worth duplicating all this, but note their final fallback in the "else" branch just pulls a name from the class. I would be satisfied with this, where all partials end up named "partial".

I implemented that, which required very little new code, so I think it's a good balance that handles my use case without complicating your codebase.